### PR TITLE
ignore "junk" folders from c# projects

### DIFF
--- a/copcon/main.py
+++ b/copcon/main.py
@@ -19,6 +19,10 @@ DEFAULT_IGNORE_DIRS = {
     "build",
     "dist",
     "target",
+    ".vs",
+    "bin",
+    "obj",
+    "publish"
 }
 
 # Default files to ignore


### PR DESCRIPTION
.vs is created by Visual Studio (Similar to .vscode and .idea folders)
bin, obj and publish are similar to build, dist and target, containing various cache, build and release files.