### PR TITLE
added support for linux using xclip and pyperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ This format provides a clear overview of your project structure followed by the 
 
 ## Note
 
-This tool is designed for macOS and Windows.
+This tool is designed for macOS and Windows. \
+**Update**: Now also available on Linux, if xclip (or similar package) is installed. Install using `$ sudo apt install xclip`
 
 ## Development
 

--- a/copcon/main.py
+++ b/copcon/main.py
@@ -6,6 +6,7 @@ import mimetypes
 import platform
 import sys
 import pathspec
+import pyperclip
 
 app = typer.Typer()
 
@@ -153,6 +154,8 @@ def get_file_content(file_path: Path) -> str:
 
 def copy_to_clipboard(text: str):
     system = platform.system()
+    
+    # pyperclip should be OS-agnostic, but as I don't have neither Windows or MacOS available, I cannot test it, hence keep the original code for MacOS and Windows
     if system == "Darwin":  # macOS
         process = subprocess.Popen(
             "pbcopy", env={"LANG": "en_US.UTF-8"}, stdin=subprocess.PIPE
@@ -166,8 +169,9 @@ def copy_to_clipboard(text: str):
         win32clipboard.SetClipboardText(text, win32clipboard.CF_UNICODETEXT)
         win32clipboard.CloseClipboard()
     else:
-        print(f"Clipboard functionality not supported on {system}")
-        sys.exit(1)
+        pyperclip.copy(text)
+        # print(f"Clipboard functionality not supported on {system}")
+        # sys.exit(1)
 
 
 @app.command()

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,6 +123,16 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyperclip"
+version = "1.9.0"
+description = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.2"
 description = "pytest: simple powerful testing with Python"
@@ -221,4 +231,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ad198c268f47bb872f2437b4ffa5cfa8cf3f3a84ee39bc7ef615e7aefd520b74"
+content-hash = "199fae043d77b53867da194686b83e8202e9e5b2a22939a1cbe687b254aa9fdd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 typer = "^0.12.3"
 pywin32 = {version = "^300", platform = "win32"}
 pathspec = "^0.12.1"
+pyperclip = "^1.8.2"  
 
 [tool.poetry.scripts]
 copcon = "copcon:copcon_app"


### PR DESCRIPTION
By adding pyperclip as a python dependency and xclip as a Linux OS dependency, support for Ubuntu can be added in the copy_to_clipboard() method by using `pyperclip.copy(text)`.
pyperclip should be OS agnostic, but I don't have neither a MacOS or Windows available to test that...

But nice work with this copcon. It's a neat trick for improved LLM usage.