### PR TITLE
Add support for .copcontarget file with updated success message and tests

### DIFF
--- a/copcon/core/autodiscover.py
+++ b/copcon/core/autodiscover.py
@@ -1,20 +1,9 @@
 """
-Auto-discovery of a .copconignore file.
+Auto-discovery of a .copconignore and .copcontarget file.
 
 This module provides functionality to walk upward from a given directory in
-search of a .copconignore file. If found, the path to this file is returned.
-Otherwise, None is returned.
-
-Usage:
-    from pathlib import Path
-    from copcon.core.autodiscover import discover_copconignore
-
-    directory = Path("/some/project/path")
-    ignore_path = discover_copconignore(directory)
-    if ignore_path:
-        print(f"Discovered .copconignore at: {ignore_path}")
-    else:
-        print("No .copconignore found.")
+search of a .copconignore or .copcontarget file. If found, the path to these
+files is returned. Otherwise, None is returned.
 """
 
 from pathlib import Path
@@ -32,6 +21,24 @@ def discover_copconignore(directory: Path) -> Optional[Path]:
         if possible_ignore.exists() and possible_ignore.is_file():
             logger.debug(f"Auto-discovered .copconignore at {possible_ignore}")
             return possible_ignore
+
+        if current.parent == current:
+            break
+        current = current.parent
+
+    return None
+
+def discover_copcontarget(directory: Path) -> Optional[Path]:
+    """
+    Attempt to walk upward from 'directory' to find a .copcontarget file.
+    Returns the file's Path if discovered, or None if not found.
+    """
+    current = directory.resolve()
+    while True:
+        possible_target = current / ".copcontarget"
+        if possible_target.exists() and possible_target.is_file():
+            logger.debug(f"Auto-discovered .copcontarget at {possible_target}")
+            return possible_target
 
         if current.parent == current:
             break

--- a/copcon/messages.py
+++ b/copcon/messages.py
@@ -14,6 +14,7 @@ def get_success_message(
     extension_token_map: Dict[str, int],
     output_file: Optional[str],
     copconignore_path: Optional[str] = None,
+    copcontarget_path: Optional[str] = None,
 ) -> str:
     """
     Generate the final success message for Copcon.
@@ -52,19 +53,22 @@ def get_success_message(
         f"{extension_table}\n\n"
     )
 
-    # 4) If a .copconignore file is in use, mention it
+    # 4) If a .copcontarget file is in use, mention it
+    if copcontarget_path:
+        base_msg += f"Using `.copcontarget` from: {copcontarget_path}\n"
+    # 5) If a .copconignore file is in use, mention it
     if copconignore_path:
         base_msg += f"Using `.copconignore` from: {copconignore_path}\n"
 
-    # 5) Mention how the report is delivered
+    # 6) Mention how the report is delivered
     if output_file:
-        base_msg += "The report has been written to " f"`{output_file}`. 🚀\n"
+        base_msg += f"\nThe report has been written to `{output_file}` 🚀\n"
     else:
-        base_msg += "The report has been copied to your clipboard. 🚀\n"
+        base_msg += "\nThe report has been copied to your clipboard 🚀\n"
 
-    # 6) Parenthetical postscript for the GitHub star
+    # 7) Parenthetical postscript for the GitHub star
     base_msg += (
-        "\n(PS: If you find Copcon useful, please star us at "
+        "\n(PS: If you find Copcon useful, please star it at "
         "github.com/kasperjunge/copcon ⭐️)"
     )
 

--- a/docs/source/core/autodiscover.rst
+++ b/docs/source/core/autodiscover.rst
@@ -1,0 +1,7 @@
+Autodiscover 
+============================
+
+.. automodule:: copcon.core.autodiscover
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "copcon"
-version = "0.3.10"
+version = "0.3.11"
 description = ""
 readme = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/tests/test_file_filter_targets.py
+++ b/tests/test_file_filter_targets.py
@@ -1,0 +1,42 @@
+import pytest
+from pathlib import Path
+from copcon.core.file_filter import FileFilter
+from copcon.exceptions import FileReadError
+
+@pytest.fixture
+def non_empty_copcontarget_file(tmp_path):
+    target_file = tmp_path / ".copcontarget"
+    target_file.write_text("*.py\n")
+    return target_file
+
+@pytest.fixture
+def empty_copcontarget_file(tmp_path):
+    target_file = tmp_path / ".copcontarget"
+    target_file.write_text("")
+    return target_file
+
+def test_file_filter_with_non_empty_copcontarget(non_empty_copcontarget_file, tmp_path):
+    # Create a FileFilter with a non-empty .copcontarget
+    file_filter = FileFilter(user_target_path=non_empty_copcontarget_file)
+    
+    # target_spec should be set because the file is non-empty
+    assert file_filter.target_spec is not None
+
+    # Create a Python file that should match the target pattern
+    py_file = tmp_path / "test.py"
+    py_file.write_text("print('hello')")
+    # Since *.py is allowed by the target, this file should not be ignored
+    assert not file_filter.should_ignore(py_file)
+
+    # Create a non-Python file that should not match the target pattern
+    txt_file = tmp_path / "readme.txt"
+    txt_file.write_text("content")
+    # Since *.txt does not match the *.py target, this file should be ignored
+    assert file_filter.should_ignore(txt_file)
+
+def test_file_filter_with_empty_copcontarget(empty_copcontarget_file):
+    # Create a FileFilter with an empty .copcontarget
+    file_filter = FileFilter(user_target_path=empty_copcontarget_file)
+
+    # target_spec should be None because the .copcontarget file was empty
+    assert file_filter.target_spec is None


### PR DESCRIPTION
This pull request introduces a new feature to Copcon: support for a `.copcontarget` file. The `.copcontarget` file allows users to specify target directories and files within a larger project to focus on, applying these patterns before the existing `.copconignore` rules. Key changes and additions include:

- **`.copcontarget` Discovery:**  
  - Added `discover_copcontarget` in `copcon/core/autodiscover.py` to automatically search for a `.copcontarget` file.
  
- **File Filtering Enhancements:**  
  - Modified `FileFilter` in `copcon/core/file_filter.py` to load and apply target patterns from a `.copcontarget` file if present.
  - If the `.copcontarget` file is empty, it is ignored as if it didn’t exist, maintaining default behavior.
  - Applied target patterns first to include only specified paths, then `.copconignore` patterns to exclude unwanted files/directories.

- **Success Message Update:**  
  - Updated `get_success_message` in `copcon/messages.py` to display information about the `.copcontarget` file when it is found and used.
  - The message now clearly states the paths of both `.copcontarget` and `.copconignore` files when applicable.

- **CLI Integration:**  
  - Updated `copcon/cli.py` to discover and pass the `.copcontarget` path to the success message function.

- **Unit Tests:**  
  - Added tests in `tests/test_messages_targets.py` to verify that the success message includes `.copcontarget` information.
  - Added tests in `tests/test_file_filter_targets.py` to ensure correct handling of non-empty and empty `.copcontarget` files, as well as proper filtering behavior based on target patterns.

**Example Success Message:**

```
🎉 Success! Copcon has processed:

📁 2 directories
📄 10 files
🔢 6,200 tokens

File Extension    | Tokens  |  Token Distribution
-------------------------------------------
.py               |   6200  | 100.0%
-------------------------------------------
Total             |   6200  | 100.0%

Using `.copcontarget` from: /path/to/.copcontarget
Using `.copconignore` from: /path/to/.copconignore

The report has been copied to your clipboard 🚀

(PS: If you find Copcon useful, please star it at github.com/kasperjunge/copcon ⭐️)
```

**Testing & Verification:**

- All existing tests pass.
- New tests for `.copcontarget` functionality have been added and verified.
- The behavior when `.copcontarget` is empty has been confirmed to follow expected logic.

This enhancement provides users with finer control over which parts of their projects are processed by Copcon, improving flexibility and efficiency.